### PR TITLE
みんなの記録をTOPに表示

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -40,6 +40,7 @@
     <div id="start" v-if="isTitle">
       <p class="descriptionText">15秒間マウスを動かして、ストレスを発散させよう!</p>
       <p class="descriptionText">スタートを押すとBGMが流れます</p>
+      <p class="descriptionText">{{ worldTotal }}</p>
       <a href="#" class="flatButton" id="startButton" v-on:click="start">スタート</a>
     </div>
     <div id="result" v-if="isResult">
@@ -60,6 +61,7 @@
   <!-- TODO: Add SDKs for Firebase products that you want to use
       https://firebase.google.com/docs/web/setup#available-libraries -->
   <script src="/__/firebase/7.19.0/firebase-analytics.js"></script>
+  <script src="/__/firebase/7.19.0/firebase-firestore.js"></script>
 
   <!-- Initialize Firebase -->
   <script src="/__/firebase/init.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,9 +38,9 @@
       </div>
     </div>
     <div id="start" v-if="isTitle">
-      <p class="descriptionText">15秒間マウスを動かして、ストレスを発散させよう!</p>
-      <p class="descriptionText">スタートを押すとBGMが流れます</p>
-      <p class="descriptionText">{{ worldTotal }}</p>
+      <p class="descriptionText">15秒間マウスを動かして、ストレスを発散させよう!<br>
+      スタートを押すとBGMが流れます</p>
+      <p class="descriptionText">みんなが消したウイルスの数 : {{ worldTotal }}</p>
       <a href="#" class="flatButton" id="startButton" v-on:click="start">スタート</a>
     </div>
     <div id="result" v-if="isResult">

--- a/docs/src/main.js
+++ b/docs/src/main.js
@@ -14,6 +14,7 @@ var game = new Vue({
   el: "#game",
   data: {
     seen: false,
+    worldTotal: 10,
     score: 0,
     image: "figs/virus_corona.png",
     bgm: new Audio("sounds/BGM.mp3"),
@@ -140,6 +141,7 @@ function gameStart(){
   game.score = 0;
   game.clearAll();
   game.startTimer();
+  getDataFromFireStore();
 }
 
 function showTitle(){
@@ -176,4 +178,21 @@ function saveData(){
     localStorage.score = game.score;
     game.highScore = game.score;
   }
+}
+
+var db = firebase.firestore();
+function getDataFromFireStore()
+{
+  var docRef = db.collection("ByeByeVirus").doc("worldTotal");
+  docRef.get().then(function(doc) {
+    if (doc.exists) {
+        // みんなの記録の合計を取得
+        console.log("Document data:", doc.data().sum);
+        game.worldTotal=  doc.data().sum;
+    } else {
+        console.log("No such document!");
+    }
+  }).catch(function(error) {
+    console.log("Error getting document:", error);
+  });
 }

--- a/docs/src/main.js
+++ b/docs/src/main.js
@@ -14,7 +14,7 @@ var game = new Vue({
   el: "#game",
   data: {
     seen: false,
-    worldTotal: 10,
+    worldTotal: "???",
     score: 0,
     image: "figs/virus_corona.png",
     bgm: new Audio("sounds/BGM.mp3"),
@@ -29,6 +29,11 @@ var game = new Vue({
     isTitle: true,
     isRunning: false,
     isResult: false,
+  }, 
+  // インスタンス生成前に
+  beforeCreate: function () {
+    // みんなの記録を取得
+    getDataFromFireStore()
   },
   methods:{
     // ウイルスの残り数を更新する
@@ -44,6 +49,8 @@ var game = new Vue({
     },
     //リスタート
     restart: function(){
+      // みんなの記録を取得
+      getDataFromFireStore();
       game.seen = false;
       sleep(1, gameStart);
     },
@@ -65,6 +72,7 @@ var game = new Vue({
         //30秒たったらゲーム終了
         if(vm.diffTime >= 15000){
           vm.clearSE.play();
+          saveDataToFireStore();
           showResult();
         }
       }());
@@ -141,10 +149,10 @@ function gameStart(){
   game.score = 0;
   game.clearAll();
   game.startTimer();
-  getDataFromFireStore();
 }
 
 function showTitle(){
+  // みんなの記録を取得
   title.seen = true;
   game.seen = false;
 }
@@ -180,9 +188,10 @@ function saveData(){
   }
 }
 
-var db = firebase.firestore();
+// FireStoreからデータを取得
 function getDataFromFireStore()
 {
+  var db = firebase.firestore();
   var docRef = db.collection("ByeByeVirus").doc("worldTotal");
   docRef.get().then(function(doc) {
     if (doc.exists) {
@@ -195,4 +204,16 @@ function getDataFromFireStore()
   }).catch(function(error) {
     console.log("Error getting document:", error);
   });
+}
+
+// FireStoreにデータを保存
+function  saveDataToFireStore() 
+{
+  var db = firebase.firestore();
+  var docRef = db.collection("ByeByeVirus").doc("worldTotal");
+  // game.worldTotal は取得済みの「みんなの記録」
+  var newWorldTotal = game.worldTotal + game.score;
+  docRef.set(
+    {sum: newWorldTotal}
+  );
 }


### PR DESCRIPTION
みんなの記録のpushとsave実装済みです
今のリスタートだと、ホームに戻らずリスタートするので
- みんなの記録をゲーム画面に表示するか
- ホームに戻らせるか
は @Yamkatsu63 にお任せします!!

みんなの記録は`game.worldTotal`で取得できます。

P.S.
- `firestore.rules`をコンソールから更新したので
ローカルのファイルも以下に更新をお願いします
```
service cloud.firestore {
  match /databases/{database}/documents {
    match /{document=**} {
      allow read, write;
    }
  }
}
```
- このブランチの最新で一応Deployはしています